### PR TITLE
Feature: Editing teams

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -14,8 +14,9 @@ injectTapEventPlugin();
 
 function getProps(el) {
   var props;
-  props = JSON.parse(el.attributes['data-react-prop'].value);
-  props.loggedIn = window.teamLeaderLoggedIn;
+  props              = JSON.parse(el.attributes['data-react-prop'].value);
+  props.loggedIn     = window.teamLeaderLoggedIn;
+  props.leaderTeamId = window.teamLeaderAssembledTeamId;
   return props;
 }
 

--- a/app/assets/javascripts/components/menu.js.jsx
+++ b/app/assets/javascripts/components/menu.js.jsx
@@ -8,8 +8,9 @@ var MenuItem = mui.MenuItem;
 var Menu = React.createClass({
 
   propTypes: {
-    title:    React.PropTypes.string.isRequired,
-    loggedIn: React.PropTypes.bool.isRequired
+    title:        React.PropTypes.string.isRequired,
+    loggedIn:     React.PropTypes.bool.isRequired,
+    leaderTeamId: React.PropTypes.number
   },
 
   openMenu: function openMenu(e) {
@@ -22,13 +23,22 @@ var Menu = React.createClass({
         type: MenuItem.Types.LINK,
         payload: '/teams',
         text: 'Leaderboard'
-      },
-      {
+      }
+    ];
+
+    if ( !!this.props.leaderTeamId ) {
+      menuItems.push({
+        type: MenuItem.Types.LINK,
+        payload: '/teams/' + this.props.leaderTeamId,
+        text: 'Your Team'
+      });
+    } else {
+      menuItems.push({
         type: MenuItem.Types.LINK,
         payload: '/teams/new',
         text: 'Assemble Team'
-      }
-    ];
+      });
+    }
 
     if ( !this.props.loggedIn ) {
       menuItems.push({

--- a/app/assets/javascripts/components/team_builder/team_builder.js.jsx
+++ b/app/assets/javascripts/components/team_builder/team_builder.js.jsx
@@ -19,7 +19,9 @@ TeamBuilder = React.createClass({
   propTypes: {
     maxExperience: React.PropTypes.number,
     maxTeamSize:   React.PropTypes.number,
-    loggedIn:      React.PropTypes.bool
+    loggedIn:      React.PropTypes.bool.isRequired,
+    leaderTeamId:  React.PropTypes.number,
+    team:          React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -27,6 +29,10 @@ TeamBuilder = React.createClass({
   },
 
   getInitialState: function() {
+    if ( !!this.props.team ) {
+      localStorage.team = JSON.stringify(this.props.team);
+    }
+
     if ( !localStorage.team ) {
       return {
         characters: [],
@@ -142,7 +148,7 @@ TeamBuilder = React.createClass({
   goToProfile: function(team) {
     setTimeout(function() {
       window.location = '/teams/' + team.id;
-    }, 1000);
+    }, 2000);
   },
 
   signIn: function() {
@@ -161,7 +167,10 @@ TeamBuilder = React.createClass({
 
     return (
       <div>
-        <Menu title="Assemble Team" loggedIn={this.props.loggedIn} />
+        <Menu title="Assemble Team"
+          loggedIn={this.props.loggedIn}
+          leaderTeamId={this.props.leaderTeamId}
+        />
         <div id="main">
           <NewTeam
             team={this.state.team}
@@ -176,7 +185,7 @@ TeamBuilder = React.createClass({
             ref="creator"
             onCreate={this.goToProfile}
             team={this.state.team} />
-          <div id="create_team_button">
+          <div id="create_team_button" className="team-floating-action-button">
             <ActionButton
               onClick={this.startAssemblingTeam}
               disabled={!this.state.team.isValid}>

--- a/app/assets/javascripts/components/team_profile/team_profile.js.jsx
+++ b/app/assets/javascripts/components/team_profile/team_profile.js.jsx
@@ -6,6 +6,7 @@ var TeamCharacters = require('./team_characters.js.jsx');
 var mui            = require('material-ui');
 var Paper          = mui.Paper;
 var Avatar         = mui.Avatar;
+var ActionButton   = mui.FloatingActionButton;
 
 var TeamProfile;
 
@@ -14,15 +15,36 @@ TeamProfile = React.createClass({
   mixins: [MarvelTheme],
 
   propTypes: {
-    loggedIn: React.PropTypes.bool.isRequired,
-    team: React.PropTypes.object.isRequired,
-    maxStats: React.PropTypes.object.isRequired
+    loggedIn:     React.PropTypes.bool.isRequired,
+    leaderTeamId: React.PropTypes.number,
+    team:         React.PropTypes.object.isRequired,
+    maxStats:     React.PropTypes.object.isRequired
+  },
+
+  editAssembledTeam: function() {
+    window.location = '/teams/' + this.props.team.id + '/edit';
   },
 
   render: function() {
+    function renderEditButton() {
+      if ( !!this.props.leaderTeamId ) {
+        return (
+          <div id="edit_team_button" className="team-floating-action-button">
+            <ActionButton
+              onClick={this.editAssembledTeam} >
+              <i className="material-icons">build</i>
+            </ActionButton>
+          </div>
+        );
+      }
+    }
+
     return (
       <div>
-        <Menu title="Team Profile" loggedIn={this.props.loggedIn} />
+        <Menu title="Team Profile"
+          loggedIn={this.props.loggedIn}
+          leaderTeamId={this.props.leaderTeamId}
+        />
         <div id="main">
           <Paper id="team_profile_header">
             <Avatar
@@ -37,6 +59,7 @@ TeamProfile = React.createClass({
             stats={this.props.team.stats}
             maxStats={this.props.maxStats} />
           <TeamCharacters characters={this.props.team.characters} />
+          {renderEditButton.call(this)}
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/team_rankings/team_rankings.js.jsx
+++ b/app/assets/javascripts/components/team_rankings/team_rankings.js.jsx
@@ -11,8 +11,9 @@ var TeamRankings = React.createClass({
   mixins: [MarvelTheme],
 
   propTypes: {
-    loggedIn: React.PropTypes.bool.isRequired,
-    teams: React.PropTypes.array.isRequired
+    loggedIn:     React.PropTypes.bool.isRequired,
+    leaderTeamId: React.PropTypes.number,
+    teams:        React.PropTypes.array.isRequired
   },
 
   render: function() {
@@ -25,7 +26,10 @@ var TeamRankings = React.createClass({
 
     return (
       <div>
-        <Menu title="Leaderboard" loggedIn={this.props.loggedIn} />
+        <Menu title="Leaderboard"
+          loggedIn={this.props.loggedIn}
+          leaderTeamId={this.props.leaderTeamId}
+        />
         <div id="main">
           {(function() {
             if ( this.props.teams.length > 0 ) {

--- a/app/assets/stylesheets/_main.sass
+++ b/app/assets/stylesheets/_main.sass
@@ -3,3 +3,11 @@
   margin: auto
   padding-top: 10px
   padding-bottom: 50px
+
+.team-floating-action-button
+  position: fixed
+  bottom: 25px
+  right: 25px
+
+  button
+    margin: 0

--- a/app/assets/stylesheets/team_builder.sass
+++ b/app/assets/stylesheets/team_builder.sass
@@ -1,7 +1,0 @@
-#create_team_button
-  position: fixed
-  bottom: 25px
-  right: 25px
-
-  button
-    margin: 0

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -8,6 +8,10 @@ class Api::V1::TeamsController < ApplicationController
     @team = UserTeamCreator.new(current_user).assemble(params[:team])
   end
 
+  def update
+    @team = UserTeamCreator.new(current_user).assemble(params[:team])
+  end
+
   private
 
   def team_params

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,4 +8,8 @@ class TeamsController < ApplicationController
     @team = Team.find(params[:id])
   end
 
+  def edit
+    @team = Team.find(params[:id])
+  end
+
 end

--- a/app/form_objects/user_team_creator.rb
+++ b/app/form_objects/user_team_creator.rb
@@ -4,7 +4,7 @@ class UserTeamCreator
 
   def initialize(user)
     @user = user
-    @team = Team.new(user: @user)
+    @team = @user.team || Team.new(user: @user)
   end
 
   def assemble(team_attributes)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -21,6 +21,8 @@ class Team < ActiveRecord::Base
   belongs_to :user
   has_and_belongs_to_many :characters, join_table: :teams_characters
 
+  validates :user_id, uniqueness: true
+
   def stats
     @stats ||= Stats.from_team(self)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ActiveRecord::Base
 
-  has_many :teams, dependent: :destroy
+  has_one :team, dependent: :destroy
 
+  # TODO: Move to form object
   def self.from_omniauth(auth)
     where(provider: auth.provider,
           uid: auth.uid).first_or_initialize.tap do |user|

--- a/app/views/api/v1/teams/update.json.jbuilder
+++ b/app/views/api/v1/teams/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/teams/team', team: @team

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,10 @@
   <body>
     <%= yield %>
     <script type="text/javascript">
-      window.teamLeaderLoggedIn = <%= current_user.present? ? 'true' : 'false' %>;
+      window.teamLeaderLoggedIn =
+        <%= current_user.present? ? 'true' : 'false' %>;
+      window.teamLeaderAssembledTeamId =
+        <%= current_user.try(:team).try(:id) || 'null' %>;
     </script>
   </body>
   <% if Rails.env.production? %>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -1,0 +1,13 @@
+<div
+  id="team_builder"
+  data-react-prop="<%= react_props({
+    team:     {
+      template: 'teams/show.json',
+      locals: {
+        team: @team
+      }
+    },
+    maxTeamSize:   UserTeamCreator::MAX_CHARACTERS,
+    maxExperience: UserTeamCreator::ALLOWED_CUMULATIVE_EXPERIENCE
+  }) %>">
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
 
   root 'teams#index'
 
-  resources :teams, only: [:new, :index, :show]
+  resources :teams, only: [:new, :index, :show, :edit]
 
   resources :sessions, only: :new
 
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
           get :camaraderie
         end
       end
-      resources :teams, only: [:create, :index]
+      resources :teams, only: [:create, :update, :index]
     end
   end
 

--- a/features/assemble_team.feature
+++ b/features/assemble_team.feature
@@ -39,8 +39,31 @@ Feature: Assembling Team
     Then I should not be able to assemble my team
     When I add Groot to my team
     Then I see Groot added to my team
+    Then I should be able to assemble my team
     When I add Groot to my team
     Then I see an alert that my team is full
     When I assemble my team
     Then I should see that my team is being assembled
+    And I should see that my team is successfully assembled
     And I should be taken to my team profile
+    And I see Iron Man on my team profile
+    And I see Black Widow on my team profile
+    And I see Jubilee on my team profile
+    And I see May Parker on my team profile
+    And I see Groot on my team profile
+
+  Scenario: Editing a team and saving while logged in
+    Given all the characters have been imported
+    And I am an authenticated user
+    And my team exists
+    When I visit my assemble team page
+    Then I should not be able to assemble my team
+    And I remove a character
+    Then I should not be able to assemble my team
+    When I add a new character
+    Then I should be able to assemble my team
+    When I assemble my team
+    Then I should see that my team is being assembled
+    And I should see that my team is successfully assembled
+    And I should be taken to my team profile
+    And I have the new character on my team profile

--- a/features/step_definitions/assemble_teams_steps.rb
+++ b/features/step_definitions/assemble_teams_steps.rb
@@ -1,10 +1,5 @@
-Given(/^I am an authenticated user$/) do
-  @user = create_user
-  page.set_rack_session(user_id: @user.id)
-end
-
 Given(/^I have not created a team$/) do
-  @user.teams.destroy_all
+  @user.team.try(:destroy)
 end
 
 Given(/^all the characters have been imported$/) do
@@ -14,24 +9,24 @@ Given(/^all the characters have been imported$/) do
 end
 
 When(/^I visit the assemble team page$/) do
-  @new_team_page = NewTeamPage.new
-  @new_team_page.load
+  @assemble_team_page = NewTeamPage.new
+  @assemble_team_page.load
 end
 
 When(/^I search for (.*)$/) do |character_name|
-  @new_team_page.search_field.set character_name
+  @assemble_team_page.search_field.set character_name
 end
 
 Then(/^I see (.*) in the results$/) do |character_name|
-  expect(@new_team_page).to have_character_results text: character_name
+  expect(@assemble_team_page).to have_character_results text: character_name
 end
 
 When(/^I add (.*) to my team$/) do |character_name|
-  @new_team_page.add_character(character_name)
+  @assemble_team_page.add_character(character_name)
 end
 
 Then(/^I see (.*) added to my team$/) do |character_name|
-  expect(@new_team_page).to have_team_member character_name
+  expect(@assemble_team_page).to have_team_member character_name
 end
 
 Then(/^I should see an alert that (.*) has already been added$/) do |character_name|
@@ -39,7 +34,7 @@ Then(/^I should see an alert that (.*) has already been added$/) do |character_n
 end
 
 Then(/^I don't see (.*) on my team$/) do |character_name|
-  expect(@new_team_page).to_not have_team_member character_name
+  expect(@assemble_team_page).to_not have_team_member character_name
 end
 
 Then(/^I see an alert that my team is too powerful$/) do
@@ -51,27 +46,59 @@ Then(/^I see an alert that my team is full$/) do
 end
 
 Then(/^I should be able to assemble my team$/) do
-  expect(@new_team_page.assemble_button['disabled']).to be_nil
+  expect(@assemble_team_page.assemble_button['disabled']).to be_nil
 end
 
 When(/^I remove (.*) from my team$/) do |character_name|
-  @new_team_page.find_team_member(character_name).click
+  @assemble_team_page.find_team_member(character_name).click
 end
 
 Then(/^I should not be able to assemble my team$/) do
-  expect(@new_team_page.assemble_button['disabled']).to eq 'true'
+  expect(@assemble_team_page.assemble_button['disabled']).to eq 'true'
 end
 
 When(/^I assemble my team$/) do
-  @new_team_page.assemble_button.click
+  @assemble_team_page.assemble_button.click
 end
 
 Then(/^I should see that my team is being assembled$/) do
-  expect(@new_team_page.creator_feedback).to have_assembling_team_message
+  expect(@assemble_team_page.creator_feedback).to have_assembling_team_message
+end
+
+Then(/^I should see that my team is successfully assembled$/) do
+  @assemble_team_page.creator_feedback.wait_for_avengers_assembled_message
 end
 
 Then(/^I should be taken to my team profile$/) do
   while Team.count.zero?; end
-  team_profile_page = TeamProfilePage.new
-  expect(team_profile_page).to be_displayed(team_id: Team.last.id)
+  @team_profile_page = TeamProfilePage.new
+  expect(@team_profile_page).to be_displayed(team_id: Team.last.id)
+end
+
+When(/^I visit my assemble team page$/) do
+  @assemble_team_page = EditTeamPage.new
+  @assemble_team_page.load(team_id: @team.id)
+end
+
+Then(/^I remove a character$/) do
+  step("I remove #{@team.characters.last.name} from my team")
+end
+
+When(/^I add a new character$/) do
+  @new_character =
+    Character.find(Character.where(experience: 0).pluck(:id).sample)
+  while @team.characters.pluck(:id).include?(@new_character.id)
+    @new_character = Character.find(Character.pluck(:id).sample)
+  end
+  step("I search for #{@new_character.name}")
+  step("I see #{@new_character.name} in the results")
+  step("I add #{@new_character.name} to my team")
+end
+
+Then(/^I have the new character on my team profile$/) do
+  step("I see #{@new_character.name} on my team profile")
+end
+
+Then(/^I see (.*) on my team profile$/) do |character_name|
+  expect(@team_profile_page).to have_character(character_name)
 end

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -1,0 +1,8 @@
+Given(/^I am an authenticated user$/) do
+  @user = create_user
+  page.set_rack_session(user_id: @user.id)
+end
+
+Given(/^my team exists$/) do
+  @team = create_team(@user)
+end

--- a/features/step_definitions/team_profile_steps.rb
+++ b/features/step_definitions/team_profile_steps.rb
@@ -41,3 +41,24 @@ Then(/^I see the superheroes on the team$/) do
     end
   end
 end
+
+Then(/^I don't see the ability to edit the team$/) do
+  expect(@team_profile).to_not have_edit_team_button
+end
+
+When(/^I visit my team profile$/) do
+  step('I visit the team profile')
+end
+
+Then(/^I see the ability to edit my team$/) do
+  expect(@team_profile).to have_edit_team_button
+end
+
+When(/^I click the button to edit my team$/) do
+  @team_profile.edit_team_button.click
+end
+
+Then(/^I'm on the edit team page$/) do
+  assemble_team_page = EditTeamPage.new
+  expect(assemble_team_page).to be_displayed(team_id: @team.id)
+end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -11,7 +11,7 @@ module Helpers
     )
   end
 
-  def create_team
+  def create_team(user = create_user)
     all_character_ids = Character.valid.original.experienced.pluck(:id)
     character_ids = []
     while character_ids.size < 5 do
@@ -19,7 +19,7 @@ module Helpers
       character_ids = character_ids.uniq
     end
 
-    UserTeamCreator.new(create_user).assemble(
+    UserTeamCreator.new(user).assemble(
       character_ids: character_ids,
       camaraderie:   200
     )

--- a/features/support/page_objects/assemble_team_page.rb
+++ b/features/support/page_objects/assemble_team_page.rb
@@ -1,0 +1,42 @@
+require_relative 'character_result_section'
+require_relative 'team_member_section'
+require_relative 'team_creator_feedback_section'
+
+class AssembleTeamPage < SitePrism::Page
+  element :search_field, '.character-search-field input'
+  element :assemble_button, '#create_team_button button'
+  sections :character_results, CharacterResultSection, '.character-result'
+  sections :team_members, TeamMemberSection, '.team-character'
+  section :creator_feedback, TeamCreatorFeedbackSection, '#team_creator_feedback'
+
+  def find_character_result(character_name)
+    character_results.detect do |cr|
+      cr.name.text.include? character_name
+    end
+  end
+
+  def find_team_member(character_name)
+    team_members.detect do |tm|
+      tm.has_id?(find_character(character_name).id)
+    end
+  end
+
+  def has_character_result?(character_name)
+    find_character_result(character_name).present?
+  end
+
+  def has_team_member?(character_name)
+    find_team_member(character_name).present?
+  end
+
+  def add_character(character_name)
+    find_character_result(character_name).add_button.click
+  end
+
+  private
+
+  def find_character(name)
+    @characters ||= {}
+    @characters[name] ||= Character.find_by(name: name)
+  end
+end

--- a/features/support/page_objects/edit_team_page.rb
+++ b/features/support/page_objects/edit_team_page.rb
@@ -1,0 +1,5 @@
+require_relative 'assemble_team_page'
+
+class EditTeamPage < AssembleTeamPage
+  set_url '/teams/{team_id}/edit'
+end

--- a/features/support/page_objects/new_team_page.rb
+++ b/features/support/page_objects/new_team_page.rb
@@ -1,44 +1,5 @@
-require_relative 'character_result_section'
-require_relative 'team_member_section'
-require_relative 'team_creator_feedback_section'
+require_relative 'assemble_team_page'
 
-class NewTeamPage < SitePrism::Page
+class NewTeamPage < AssembleTeamPage
   set_url '/teams/new'
-
-  element :search_field, '.character-search-field input'
-  element :assemble_button, '#create_team_button button'
-  sections :character_results, CharacterResultSection, '.character-result'
-  sections :team_members, TeamMemberSection, '.team-character'
-  section :creator_feedback, TeamCreatorFeedbackSection, '#team_creator_feedback'
-
-  def find_character_result(character_name)
-    character_results.detect do |cr|
-      cr.name.text.include? character_name
-    end
-  end
-
-  def find_team_member(character_name)
-    team_members.detect do |tm|
-      tm.has_id?(find_character(character_name).id)
-    end
-  end
-
-  def has_character_result?(character_name)
-    find_character_result(character_name).present?
-  end
-
-  def has_team_member?(character_name)
-    find_team_member(character_name).present?
-  end
-
-  def add_character(character_name)
-    find_character_result(character_name).add_button.click
-  end
-
-  private
-
-  def find_character(name)
-    @characters ||= {}
-    @characters[name] ||= Character.find_by(name: name)
-  end
 end

--- a/features/support/page_objects/team_creator_feedback_section.rb
+++ b/features/support/page_objects/team_creator_feedback_section.rb
@@ -1,5 +1,6 @@
 class TeamCreatorFeedbackSection < SitePrism::Section
 
-  element :assembling_team_message, '.creating-message'
+  element :assembling_team_message,    '.creating-message'
+  element :avengers_assembled_message, '.success-message'
 
 end

--- a/features/support/page_objects/team_profile_page.rb
+++ b/features/support/page_objects/team_profile_page.rb
@@ -4,10 +4,15 @@ require_relative 'team_profile_character_section'
 class TeamProfilePage < SitePrism::Page
   set_url '/teams{/team_id}'
 
-  element :leader_avatar, '#leader_avatar'
-  element :team_name,     '#team_name'
-  element :team_rank,     '#team_rank'
+  element :leader_avatar,    '#leader_avatar'
+  element :team_name,        '#team_name'
+  element :team_rank,        '#team_rank'
+  element :edit_team_button, '#edit_team_button button'
 
   section  :stats,      TeamStatsSection,            '#team_stats'
   sections :characters, TeamProfileCharacterSection, '.team-profile-character'
+
+  def has_character?(character_name)
+    characters.detect { |c| c.name.text == character_name }.present?
+  end
 end

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -8,4 +8,5 @@ end
 VCR.cucumber_tags do |t|
   t.tag '@vcr', use_scenario_name: true
   t.tag '@vcrpath', use_scenario_name: true, match_requests_on: [:method, :path]
+  t.tag '@vcrall', use_scenario_name: true, record: :all
 end

--- a/features/support/vcr_cassettes/Assembling_Team/Editing_a_team_and_saving_while_logged_in.yml
+++ b/features/support/vcr_cassettes/Assembling_Team/Editing_a_team_and_saving_while_logged_in.yml
@@ -1,0 +1,373 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=31d3cfdea50e4ae73bffd02380c2ef2a&limit=1&sharedAppearances=1009220,1011159&ts=1439363471
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:52 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:12 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6d4ba3af59cc06fc56ad86a526ae24ed&limit=1&sharedAppearances=1010733,1011159&ts=1439363472
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:33 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:12 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6d4ba3af59cc06fc56ad86a526ae24ed&limit=1&sharedAppearances=1009589,1011159&ts=1439363472
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:52 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:13 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=bfaa5ff0b9bd7e0c8932a6a5c24cbd56&limit=1&sharedAppearances=1010371,1011159&ts=1439363473
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:53 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:13 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=bfaa5ff0b9bd7e0c8932a6a5c24cbd56&limit=1&sharedAppearances=1009220,1010733&ts=1439363473
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:34 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:13 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=bfaa5ff0b9bd7e0c8932a6a5c24cbd56&limit=1&sharedAppearances=1009220,1009589&ts=1439363473
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:35 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:14 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6387e9e284a11b88a21e496e61e0d1a0&limit=1&sharedAppearances=1009220,1010371&ts=1439363474
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:54 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:14 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6387e9e284a11b88a21e496e61e0d1a0&limit=1&sharedAppearances=1010733,1009589&ts=1439363474
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:35 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:14 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6387e9e284a11b88a21e496e61e0d1a0&limit=1&sharedAppearances=1010733,1010371&ts=1439363474
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:35 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:14 GMT
+- request:
+    method: get
+    uri: http://gateway.marvel.com/v1/public/comics?apikey=534a1c83ec57591f6de64ea33b87d483&hash=6387e9e284a11b88a21e496e61e0d1a0&limit=1&sharedAppearances=1009589,1010371&ts=1439363474
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - dba3400fdf9f13c96425c48195b1441de97a2f75
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2015 07:12:55 GMT
+      Connection:
+      - keep-alive
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJjb2RlIjoyMDAsInN0YXR1cyI6Ik9rIiwiY29weXJpZ2h0IjoiwqkgMjAx
+        NSBNQVJWRUwiLCJhdHRyaWJ1dGlvblRleHQiOiJEYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUwiLCJhdHRyaWJ1dGlvbkhUTUwiOiI8
+        YSBocmVmPVwiaHR0cDovL21hcnZlbC5jb21cIj5EYXRhIHByb3ZpZGVkIGJ5
+        IE1hcnZlbC4gwqkgMjAxNSBNQVJWRUw8L2E+IiwiZXRhZyI6ImRiYTM0MDBm
+        ZGY5ZjEzYzk2NDI1YzQ4MTk1YjE0NDFkZTk3YTJmNzUiLCJkYXRhIjp7Im9m
+        ZnNldCI6MCwibGltaXQiOjEsInRvdGFsIjowLCJjb3VudCI6MCwicmVzdWx0
+        cyI6W119fQ==
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 07:11:15 GMT
+recorded_with: VCR 2.9.2

--- a/features/team_profile.feature
+++ b/features/team_profile.feature
@@ -10,3 +10,13 @@ Feature: Viewing an Team Profile
     And I see the team rank
     And I see the team stats
     And I see the superheroes on the team
+    And I don't see the ability to edit the team
+
+  Scenario: Visiting your team profile page
+    Given all the characters have been imported
+    And I am an authenticated user
+    And my team exists
+    When I visit my team profile
+    Then I see the ability to edit my team
+    When I click the button to edit my team
+    Then I'm on the edit team page


### PR DESCRIPTION
# Summary

Allows editing teams
## Why

Need to be able to edit teams vs just creating new ones since the
system should only support a user having one team to make it simpler for
now.
## This change addresses the need by

Change relationship of user and teams to one to one. Allow editing team
from profile and team builder component can now accept team prop to
preload team characters.

Closes https://github.com/rsnorman/avengersassemble/issues/15
