### PR TITLE
Fix issue where team stats keep increasing on update

### DIFF
--- a/app/form_objects/user_team_creator.rb
+++ b/app/form_objects/user_team_creator.rb
@@ -8,8 +8,9 @@ class UserTeamCreator
   end
 
   def assemble(team_attributes)
-    @team.characters = Character.where(id: team_attributes[:character_ids])
+    reset_team_stats
 
+    @team.characters = Character.where(id: team_attributes[:character_ids])
     @team.characters.each do |character|
       Ratings::RATING_NAMES.each { |r| set_rating_value(character, r) }
       @team.total_experience += character.experience
@@ -40,6 +41,10 @@ class UserTeamCreator
   end
 
   private
+
+  def reset_team_stats
+    Stats::STAT_NAMES.each { |s| @team.public_send("total_#{s}=", 0)  }
+  end
 
   def character_pairs
     @character_pairs ||= CharacterPairs.new(@team.characters).pairs


### PR DESCRIPTION
## Summary
## Why

Teams kept increasing in strength every time characters were updating
because that stats were being added to the previous stat values on a
team.
## How this address the need

Resets the team stats before updating the characters
## Side effects

Resets team stats even if they are zero already

Closes: https://github.com/rsnorman/avengersassemble/issues/44
