### PR TITLE
Stop showing edit button on other's team profile

### DIFF
--- a/app/assets/javascripts/components/team_profile/team_profile.js.jsx
+++ b/app/assets/javascripts/components/team_profile/team_profile.js.jsx
@@ -27,7 +27,7 @@ TeamProfile = React.createClass({
 
   render: function() {
     function renderEditButton() {
-      if ( !!this.props.leaderTeamId ) {
+      if ( this.props.leaderTeamId === this.props.team.id ) {
         return (
           <div id="edit_team_button" className="team-floating-action-button">
             <ActionButton

--- a/app/assets/javascripts/main.bundle.js
+++ b/app/assets/javascripts/main.bundle.js
@@ -41269,7 +41269,7 @@
 
 	  render: function() {
 	    function renderEditButton() {
-	      if ( !!this.props.leaderTeamId ) {
+	      if ( this.props.leaderTeamId === this.props.team.id ) {
 	        return (
 	          React.createElement("div", {id: "edit_team_button", className: "team-floating-action-button"}, 
 	            React.createElement(ActionButton, {

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -9,7 +9,7 @@ class TeamsController < ApplicationController
   end
 
   def edit
-    @team = Team.find(params[:id])
+    @team = current_user.team
   end
 
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -16,6 +16,8 @@ class Character < ActiveRecord::Base
   scope :experienced,   -> { where('experience IS NOT NULL') }
   scope :inexperienced, -> { where(experience: nil) }
 
+  default_scope -> { order(experience: :desc, name: :asc) }
+
   def ratings
     @ratings ||= Ratings.from_character(self)
   end

--- a/features/team_profile.feature
+++ b/features/team_profile.feature
@@ -1,8 +1,21 @@
 @javascript
 Feature: Viewing an Team Profile
 
-  Scenario: Visiting not your team profile page
+  Scenario: Visiting a team profile while not logged in
     Given all the characters have been imported
+    And a team exists
+    When I visit the team profile
+    Then I see the team name
+    And I see the leader avatar
+    And I see the team rank
+    And I see the team stats
+    And I see the superheroes on the team
+    And I don't see the ability to edit the team
+
+  Scenario: Visiting another team's profile page
+    Given all the characters have been imported
+    And I am an authenticated user
+    And my team exists
     And a team exists
     When I visit the team profile
     Then I see the team name


### PR DESCRIPTION
## Summary

Removed the button from showing up on other's team profile page
## Why

The button was showing up on the team profile page giving the impression
that any team was editable. This was not the case and would just save
the characters to your team.
## This change addresses the need by

Check to make sure the team id matches the user's team id when on a
profile page
## Side effects

No way for an admin user to edit another team

Closes https://github.com/rsnorman/avengersassemble/issues/43
