### PR TITLE
Allow ultra-experienced characters on team

### DIFF
--- a/app/form_objects/user_team_creator.rb
+++ b/app/form_objects/user_team_creator.rb
@@ -13,7 +13,8 @@ class UserTeamCreator
     @team.characters = Character.where(id: team_attributes[:character_ids])
     @team.characters.each do |character|
       Ratings::RATING_NAMES.each { |r| set_rating_value(character, r) }
-      @team.total_experience += character.experience
+      @team.total_experience +=
+        [ALLOWED_CUMULATIVE_EXPERIENCE, character.experience].min
     end
 
     @team.total_camaraderie = team_attributes[:camaraderie] || total_camaraderie

--- a/app/views/api/v1/characters/_character.json.jbuilder
+++ b/app/views/api/v1/characters/_character.json.jbuilder
@@ -9,6 +9,8 @@ json.name character.name
 json.real_name character.real_name
 json.description description
 json.ratings character.ratings
-json.experience character.experience
+json.experience(
+  [UserTeamCreator::ALLOWED_CUMULATIVE_EXPERIENCE, character.experience].min
+)
 json.soldier_type character.soldier_type.name
 json.thumbnail_url character.thumbnail_image.url


### PR DESCRIPTION
## Why

Some characters were too powerful to even be added to a team based on
the experience limit
## This change addresses the need by

Don't allow a characters experience to be any greater than team
experience limit

Closes issue #52
