### PR TITLE
Make assembling dialog modal

### DIFF
--- a/app/assets/javascripts/components/team_builder/team_builder.js.jsx
+++ b/app/assets/javascripts/components/team_builder/team_builder.js.jsx
@@ -196,8 +196,7 @@ TeamBuilder = React.createClass({
             ref="modal"
             title="Sign In"
             actions={standardActions}
-            actionFocus="submit"
-            modal={this.state.modal}>
+            actionFocus="submit">
             Please sign in using your Facebook account to assemble your team.
           </Dialog>
         </div>

--- a/app/assets/javascripts/components/team_builder/team_creator.js.jsx
+++ b/app/assets/javascripts/components/team_builder/team_creator.js.jsx
@@ -173,7 +173,10 @@ TeamCreatorFeedback = React.createClass({
     }
     return (
       <div id="team_creator_feedback">
-        <Dialog ref="modal" title="Assembling Team">
+        <Dialog
+          ref="modal"
+          title="Assembling Team"
+          modal={true}>
           {renderMessage.call(this)}
         </Dialog>
       </div>

--- a/app/assets/javascripts/main.bundle.js
+++ b/app/assets/javascripts/main.bundle.js
@@ -40229,8 +40229,7 @@
 	            ref: "modal", 
 	            title: "Sign In", 
 	            actions: standardActions, 
-	            actionFocus: "submit", 
-	            modal: this.state.modal}, 
+	            actionFocus: "submit"}, 
 	            "Please sign in using your Facebook account to assemble your team."
 	          )
 	        )
@@ -40421,7 +40420,10 @@
 	    }
 	    return (
 	      React.createElement("div", {id: "team_creator_feedback"}, 
-	        React.createElement(Dialog, {ref: "modal", title: "Assembling Team"}, 
+	        React.createElement(Dialog, {
+	          ref: "modal", 
+	          title: "Assembling Team", 
+	          modal: true}, 
 	          renderMessage.call(this)
 	        )
 	      )


### PR DESCRIPTION
## Why

Users could click out of the assembling dialog while creating a team,
which would screw up the flow
## This change addresses the need by

Pass true to make Material UI dialog a modal

Closes issue #47
